### PR TITLE
fix: safezone align when using CloseAll()

### DIFF
--- a/src/menu/RageUI.lua
+++ b/src/menu/RageUI.lua
@@ -379,6 +379,7 @@ function RageUI.CloseAll()
     end
     RageUI.Options = 0
     RageUI.ItemOffset = 0
+	ResetScriptGfxAlign()
 end
 
 ---Banner


### PR DESCRIPTION
The menu messed up the whole safezone resulting in improper drawing using natives when you use RageUI.CloseAll()

But it fixes the safezone when you open it, so there's a fix for it