### PR TITLE
Add StatisticPanelAdvanced

### DIFF
--- a/src/menu/panels/UIStatisticsPanel.lua
+++ b/src/menu/panels/UIStatisticsPanel.lua
@@ -36,3 +36,51 @@ function RageUI.StatisticPanel(Percent, Text, Index)
         end
     end
 end
+
+
+
+---StatisticPanelAdvanced
+---@param Percent number
+---@param RGBA1 Table {R,G,B,A}
+---@param Percent2 number
+---@param RGBA2 Table {R,G,B,A}
+---@param RGBA3 Table {R,G,B,A}
+---@param Text string
+---@param Index number
+---@return void
+---@public
+function RageUI.StatisticPanelAdvanced(Text, Percent, RGBA1, Percent2, RGBA2, RGBA3, Index)
+    local CurrentMenu = RageUI.CurrentMenu
+    if CurrentMenu ~= nil then
+        if CurrentMenu() and (Index == nil or (CurrentMenu.Index == Index)) then
+
+
+            RGBA1 = RGBA1 or {255,255,255,255}
+
+            ---@type number
+            RenderRectangle(CurrentMenu.X, CurrentMenu.Y + Statistics.Background.Y + CurrentMenu.SubtitleHeight + RageUI.ItemOffset + (RageUI.StatisticPanelCount * 42), Statistics.Background.Width + CurrentMenu.WidthOffset, Statistics.Background.Height, 0, 0, 0, 170)
+            RenderText(Text or "", CurrentMenu.X + Statistics.Text.Left.X + (CurrentMenu.WidthOffset / 2), (RageUI.StatisticPanelCount * 40) + CurrentMenu.Y + Statistics.Text.Left.Y + CurrentMenu.SubtitleHeight + RageUI.ItemOffset, 0, Statistics.Text.Left.Scale, 245, 245, 245, 255, 0)
+            RenderRectangle(CurrentMenu.X + Statistics.Bar.X + (CurrentMenu.WidthOffset / 2), (RageUI.StatisticPanelCount * 40) + CurrentMenu.Y + Statistics.Bar.Y + CurrentMenu.SubtitleHeight + RageUI.ItemOffset, Statistics.Bar.Width, Statistics.Bar.Height, 87, 87, 87, 255)
+            RenderRectangle(CurrentMenu.X + Statistics.Bar.X + (CurrentMenu.WidthOffset / 2), (RageUI.StatisticPanelCount * 40) + CurrentMenu.Y + Statistics.Bar.Y + CurrentMenu.SubtitleHeight + RageUI.ItemOffset, Percent * Statistics.Bar.Width, Statistics.Bar.Height, RGBA1[1], RGBA1[2], RGBA1[3], RGBA1[4])
+            
+
+            RGBA2 = RGBA2 or {0, 153, 204,255}
+            RGBA3 = RGBA3 or {185, 0, 0,255}
+
+            if Percent2 and Percent2 > 0 then
+                local X = CurrentMenu.X + Statistics.Bar.X + (CurrentMenu.WidthOffset / 2)+Percent * Statistics.Bar.Width
+                RenderRectangle(X, (RageUI.StatisticPanelCount * 40) + CurrentMenu.Y + Statistics.Bar.Y + CurrentMenu.SubtitleHeight + RageUI.ItemOffset, Percent2 * Statistics.Bar.Width, Statistics.Bar.Height, RGBA2[1], RGBA2[2], RGBA2[3], RGBA2[4])
+            elseif Percent2 and Percent2 < 0 then
+                local X = CurrentMenu.X + Statistics.Bar.X + (CurrentMenu.WidthOffset / 2)+Percent * Statistics.Bar.Width
+                RenderRectangle(X, (RageUI.StatisticPanelCount * 40) + CurrentMenu.Y + Statistics.Bar.Y + CurrentMenu.SubtitleHeight + RageUI.ItemOffset, Percent2 * Statistics.Bar.Width, Statistics.Bar.Height, RGBA3[1], RGBA3[2], RGBA3[3], RGBA3[4])
+            end
+
+            for i = 1, #Statistics.Divider, 1 do
+                RenderRectangle(CurrentMenu.X + i * 40 + 193 + (CurrentMenu.WidthOffset / 2), (RageUI.StatisticPanelCount * 40) + CurrentMenu.Y + Statistics.Divider[i].Y + CurrentMenu.SubtitleHeight + RageUI.ItemOffset, Statistics.Divider[i].Width, Statistics.Divider[i].Height, 0, 0, 0, 255)
+            end
+
+            RageUI.StatisticPanelCount = RageUI.StatisticPanelCount + 1
+        end
+    end
+end
+


### PR DESCRIPTION
This function just add the possibility to make smth like that :
![Capture](https://user-images.githubusercontent.com/35814039/80489255-d7953600-895f-11ea-8f3c-a029da97a936.JPG)
Or in a more gtalike way : 
![image](https://user-images.githubusercontent.com/35814039/80489334-f4316e00-895f-11ea-8c3e-1aeeb618437b.png)
![image](https://user-images.githubusercontent.com/35814039/80489361-fe536c80-895f-11ea-83bf-e7fd0c75a9ac.png)

 - The first param is the text to draw (exactly like in the normal one)

 - The second one is the percentage of the base line (exactly like in the normal 
one)

 - The third one is the RGBA color of the base bar, (if nil then it's became {255,255,255,255})

 - The fourth one is the percentage of the second bar, it's gonna draw a bar at the end of the base bar (watch the picture to understand)

 - The fifth one is the RGBA color for the second bar if the percentage is positive ( default : {0, 153, 204,255} the blue of GTA)

 - The sixth one is the RGBA color for the second bar if the percentage is negative ( default : {185, 0, 0,255}} the red of GTA)




- EXEMPLE : 


- RageUI.StatisticPanelAdvanced("TEST", 0.50, nil, -0.1, nil, nil)  will make that
![Capture](https://user-images.githubusercontent.com/35814039/80490071-1aa3d900-8961-11ea-9029-4a9e14428596.JPG)

- RageUI.StatisticPanelAdvanced("TEST", 0.50, nil, 0.1, nil, nil)  will make that
![Capture](https://user-images.githubusercontent.com/35814039/80490153-3c04c500-8961-11ea-9fb0-89d8e394ba1d.JPG)

If you need help with this, contact me on discord : LH_Lawliet#6828