### PR TITLE
Prevent errors due to Closed function not existing

### DIFF
--- a/src/client/menu/RageUI.lua
+++ b/src/client/menu/RageUI.lua
@@ -342,7 +342,9 @@ function RageUI.Visible(Menu, Value)
             if type(Value) == "boolean" then
                 if Value then
                     if RageUI.CurrentMenu ~= nil then
-			RageUI.CurrentMenu.Closed()
+			if RageUI.CurrentMenu.Closed ~= nil then
+                            RageUI.CurrentMenu.Closed()
+                        end
                         RageUI.CurrentMenu.Open = not Value
                     end
                     Menu:UpdateInstructionalButtons(Value);


### PR DESCRIPTION
If this function is triggered and there is no Closed() function defined in the script, it errors. Adding an if statement to ensure that it exists can prevent this.