### PR TITLE
In-depth example menu

### DIFF
--- a/example.lua
+++ b/example.lua
@@ -14,13 +14,22 @@
 
 print("^1 RageUI - testing file is started. ^0")
 
+-- Create Menu
+-- https://rageui.dylan-malandain.io/docs/master/create-menu
 RMenu.Add('showcase', 'main', RageUI.CreateMenu("RageUI", "Subtitle"))
+
+-- Create SubMenus
+-- https://rageui.dylan-malandain.io/docs/master/create-submenu
 RMenu.Add('showcase', 'items', RageUI.CreateSubMenu(RMenu:Get('showcase', 'main'), "Items showcase", "RAGEUI"))
 RMenu.Add('showcase', 'panels', RageUI.CreateSubMenu(RMenu:Get('showcase', 'main'), "Panels showcase", "RAGEUI"))
+RMenu.Add('showcase', 'heritage', RageUI.CreateSubMenu(RMenu:Get('showcase', 'main'), "Heritage showcase", "RAGEUI"))
 
+-- RMenu
+-- https://rageui.dylan-malandain.io/docs/master/rmenu
 local mainMenu = RMenu:Get('showcase', 'main')
 local itemsMenu = RMenu:Get('showcase', 'items')
 local panelsMenu = RMenu:Get('showcase', 'panels')
+local heritageMenu = RMenu:Get('showcase', 'heritage')
 
 mainMenu:SetSubtitle("RageUI Showcase")
 
@@ -32,6 +41,8 @@ mainMenu.onIndexChange = function(Index)
     print(Index)
 end
 
+-- Menu Settings
+-- https://rageui.dylan-malandain.io/docs/master/menu-settings
 itemsMenu:SetSpriteBanner("casinoui_cards_blackjack_high", "casinoui_cards_blackjack_high")
 itemsMenu:DisplayGlare(false)
 itemsMenu:SetTitle("")
@@ -40,10 +51,24 @@ itemsMenu:SetSubtitle("Items showcase")
 panelsMenu:EditSpriteColor(0,0,255,25)
 panelsMenu:DisplayGlare(true)
 panelsMenu.EnableMouse = true
+panelsMenu:DisplayInstructionalButton(false)
 
+-- It's not required to use a sprite.
+heritageMenu:SetRectangleBanner(0,25,0,255)
+panelsMenu:DisplayGlare(true)
+
+-- Keys
+-- https://rageui.dylan-malandain.io/docs/master/keys
 Keys.Register('E', 'E', 'Open RageUI Showcase menu default.', function()
     RageUI.Visible(mainMenu, not RageUI.Visible(mainMenu))
 end)
+
+-- Store Values
+
+local heritage = {
+    mum = 0,
+    dad = 23
+}
 
 Citizen.CreateThread(function()
     while (true) do
@@ -61,7 +86,7 @@ Citizen.CreateThread(function()
                 end,
                 onActive = function()
             
-                end,
+                end
             }, itemsMenu)
 
             RageUI.Item.Button('Panels Showcase', "Go to the panels showcase", { RightLabel = "→→→" }, true, {
@@ -73,8 +98,21 @@ Citizen.CreateThread(function()
                 end,
                 onActive = function()
             
-                end,
+                end
             }, panelsMenu)
+
+            RageUI.Item.Button("Windows Showcase", "Go to window showcase", { RightLabel = "→→→"}, true,  {
+                onHovered = function()
+            
+                end,
+                onSelected = function()
+            
+                end,
+                onActive = function()
+            
+                end
+            }, heritageMenu)
+
         end, function()
             -- Panels
         end)
@@ -210,6 +248,9 @@ Citizen.CreateThread(function()
             RageUI.Item.Button('Advanced Statistics Panel', "", { RightLabel = "" }, true, {})
         end, function() 
             -- Panels
+
+            -- Colour Panel
+            -- https://rageui.dylan-malandain.io/docs/master/panel-colour
             RageUI.Panel.ColourPanel('Haircut Colours', RageUI.PanelColour.HairCut, 5, {
                 onColourChange = function(Index)
 
@@ -219,6 +260,8 @@ Citizen.CreateThread(function()
                 end
             }, 1)
 
+            -- Grid Panel
+            -- https://rageui.dylan-malandain.io/docs/master/panel-grid
             RageUI.Panel.Grid(0.5, 0.2, 'Top', 'Bottom', 'Left', 'Right', {
                 onPositionChange = function(X, Y)
                     print(X, Y)
@@ -228,6 +271,8 @@ Citizen.CreateThread(function()
                 end
             }, 2)
 
+            -- Horizontal Grid
+            -- https://rageui.dylan-malandain.io/docs/master/panel-horizontal-grid
             RageUI.Panel.GridHorizontal(0.1, 'Left', 'Right', {
                 onPositionChange = function(X, Y)
                     print(X, Y)
@@ -237,6 +282,8 @@ Citizen.CreateThread(function()
                 end
             }, 3)
 
+            -- Vertical Grid
+            -- https://rageui.dylan-malandain.io/docs/master/panel-vertical-grid
             RageUI.Panel.GridVertical(0.1, 'Top', 'Bottom', {
                 onPositionChange = function(X, Y)
                     print(X, Y)
@@ -246,6 +293,8 @@ Citizen.CreateThread(function()
                 end
             }, 4)
 
+            -- Percentage Panel
+            -- https://rageui.dylan-malandain.io/docs/master/panel-percentage
             RageUI.Panel.PercentagePanel(1.0, "Percentage Panel", "0", "1", {
                 onPercentageChange = function(Percentage)
                     print(Percentage)
@@ -255,13 +304,53 @@ Citizen.CreateThread(function()
                 end
             }, 5)
 
+            -- Statistic Panel
+            -- https://rageui.dylan-malandain.io/docs/master/panel-statitics
             RageUI.Panel.StatisticPanel(0.5, "Statistic #1", 6)
             RageUI.Panel.StatisticPanel(0.7, "Statistic #2", 6)
             RageUI.Panel.StatisticPanel(0.2, "Statistic #3", 6)
 
+            -- Advanced Statistic Panel
+            -- NOT DOCUMENTED
             RageUI.Panel.StatisticPanelAdvanced("Statistic #1", 0.2, {255,0,0,255}, 0.8, {0,255,0,255}, {255,255,255,255}, 7)
             RageUI.Panel.StatisticPanelAdvanced("Statistic #2", 0.8, {255,0,0,255}, 0, {0,255,0,255}, {255,255,255,255}, 7)
             RageUI.Panel.StatisticPanelAdvanced("Statistic #1", 0.6, {255,0,0,255}, 0.1, {0,255,0,255}, {255,255,255,255}, 7)
         end)
+
+        -- Windows Menu
+        RageUI.IsVisible(heritageMenu, function()
+            -- Items
+
+            -- Heritage Window
+            -- https://rageui.dylan-malandain.io/docs/master/window-heritage
+            RageUI.Window.Heritage(heritage.mum,heritage.dad)
+
+
+            RageUI.Item.List("Mother", { "1", "2", "3", "4" }, 1, nil, {}, true, {
+                onListChange = function(Index, Items)
+                    heritage.mum = Index
+                end,
+                onSelected = function(Index, Items)
+           
+                end,
+                onHovered = function(Index, Items)
+           
+                end
+            })
+
+            RageUI.Item.List("Father", { "1", "2", "3", "4" }, 1, nil, {}, true, {
+                onListChange = function(Index, Items)
+                    heritage.dad = Index
+                end,
+                onSelected = function(Index, Items)
+           
+                end,
+                onHovered = function(Index, Items)
+           
+                end
+            })
+        end, function() 
+            -- Panels
+        end)           
     end
 end)

--- a/example.lua
+++ b/example.lua
@@ -14,72 +14,203 @@
 
 print("^1 RageUI - testing file is started. ^0")
 
-RMenu.Add('showcase', 'main', RageUI.CreateMenu("RageUI", "Undefined for using SetSubtitle"))
-RMenu:Get('showcase', 'main'):SetSubtitle("RageUI Showcase")
-RMenu:Get('showcase', 'main'):DisplayGlare(true);
+RMenu.Add('showcase', 'main', RageUI.CreateMenu("RageUI", "Subtitle"))
+RMenu.Add('showcase', 'items', RageUI.CreateSubMenu(RMenu:Get('showcase', 'main'), "Items showcase", "RAGEUI"))
+RMenu.Add('showcase', 'panels', RageUI.CreateSubMenu(RMenu:Get('showcase', 'main'), "Panels showcase", "RAGEUI"))
 
+local mainMenu = RMenu:Get('showcase', 'main')
+local itemsMenu = RMenu:Get('showcase', 'items')
+local panelsMenu = RMenu:Get('showcase', 'panels')
 
-RMenu:Get('showcase', 'main').Closed = function()
-    print('Closed Showcase Menu')
-end;
-RMenu:Get('showcase', 'main').onIndexChange = function(Index)
+mainMenu:SetSubtitle("RageUI Showcase")
+
+mainMenu.Closed = function()
+    print('closed menu!')
+end
+
+mainMenu.onIndexChange = function(Index)
     print(Index)
 end
 
-RMenu.Add('showcase', 'submenu', RageUI.CreateSubMenu(RMenu:Get('showcase', 'main'), "SubMenu", "RAGEUI"))
-RMenu:Get('showcase', 'submenu').EnableMouse = true
+itemsMenu:SetSpriteBanner("casinoui_cards_blackjack_high", "casinoui_cards_blackjack_high")
+itemsMenu:DisplayGlare(false)
+itemsMenu:SetTitle("")
+itemsMenu:SetSubtitle("Items showcase")
 
-RMenu:Get('showcase', 'submenu').Closed = function()
-    print('Closed Showcase Menu')
-end;
-
-RMenu:Get('showcase', 'submenu').onIndexChange = function(Index)
-    print(Index)
-end
+panelsMenu:EditSpriteColor(0,0,255,25)
+panelsMenu:DisplayGlare(true)
+panelsMenu.EnableMouse = true
 
 Keys.Register('E', 'E', 'Open RageUI Showcase menu default.', function()
-    RageUI.Visible(RMenu:Get('showcase', 'main'), not RageUI.Visible(RMenu:Get('showcase', 'main')))
+    RageUI.Visible(mainMenu, not RageUI.Visible(mainMenu))
 end)
 
 Citizen.CreateThread(function()
     while (true) do
         Citizen.Wait(1.0)
 
-        RageUI.IsVisible(RMenu:Get('showcase', 'main'), function()
+        -- Main menu
+        RageUI.IsVisible(mainMenu, function()
+            -- Items
+            RageUI.Item.Button('Items Showcase', "Go to the items showcase", { RightLabel = "→→→" }, true, {
+                onHovered = function()
+            
+                end,
+                onSelected = function()
+            
+                end,
+                onActive = function()
+            
+                end,
+            }, itemsMenu)
 
-            for i = 1, 20 do
-                RageUI.Item.Button('Basic Items', nil, {  }, true, {
-                    onHovered = function()
-
-                    end,
-                    onSelected = function()
-
-                    end,
-                    onActive = function()
-
-                    end,
-                })
-            end
-
+            RageUI.Item.Button('Panels Showcase', "Go to the panels showcase", { RightLabel = "→→→" }, true, {
+                onHovered = function()
+            
+                end,
+                onSelected = function()
+            
+                end,
+                onActive = function()
+            
+                end,
+            }, panelsMenu)
+        end, function()
+            -- Panels
         end)
 
-        RageUI.IsVisible(RMenu:Get('showcase', 'submenu'), function()
-            for i = 1, 11 do
-                RageUI.Item.List("List Items", { "Yes", "No", "Maybe ?", "Money" }, 1, nil, {}, true, {
-                    onListChange = function(Index, Items)
+        -- Items Menu
+        RageUI.IsVisible(itemsMenu, function()
+            -- Items
 
-                    end,
-                    onSelected = function(Index, Items)
+            -- Button
+            -- https://rageui.dylan-malandain.io/docs/master/item-button
+            RageUI.Item.Button('Button', "", { RightLabel = "" }, true, {
+                onHovered = function()
+            
+                end,
+                onSelected = function()
+            
+                end,
+                onActive = function()
+            
+                end,
+            })
 
-                    end,
-                    onHovered = function(Index, Items)
+            -- Checkbox
+            -- https://rageui.dylan-malandain.io/docs/master/item-checkbox
+            RageUI.Item.Checkbox("Checkbox", "", true,  { }, {
+                onHovered = function()
 
-                    end
-                })
-            end
-        end, function()
+                end,
+                onChecked = function()
 
-            RageUI.Panel.ColourPanel('Title', RageUI.PanelColour.HairCut, 5, {
+                end,
+                onUnChecked = function()
+
+                end,
+                onSelected = function(boolean)
+                    
+                end
+            })
+
+            -- List
+            -- https://rageui.dylan-malandain.io/docs/master/item-lists
+            RageUI.Item.List("List Items", { "This", "Is", "A", "List" }, 1, nil, {}, true, {
+                onListChange = function(Index, Items)
+           
+                end,
+                onSelected = function(Index, Items)
+           
+                end,
+                onHovered = function(Index, Items)
+           
+                end
+            })
+
+           -- Progress
+           -- https://rageui.dylan-malandain.io/docs/master/item-progress
+            RageUI.Item.Progress("Progress List", { "1", "2", "3", "4" }, 1, "Description",  true, true, {
+                onListChange = function(Index)
+                    print(Index)
+                end,
+                onSelected = function(Index)
+       
+                end,
+                onHovered = function()
+       
+                end
+            })
+
+           -- Seperator
+           -- https://rageui.dylan-malandain.io/docs/master/item-separator
+            RageUI.Item.Separator('Seperator')
+
+           -- Slider
+           -- https://rageui.dylan-malandain.io/docs/master/item-slider
+            RageUI.Item.Slider("Slider", { "First", "Second", "Third", "Fourth" }, 1, "Description",  true, {}, true, {
+                onSliderChange = function(Index)
+                    print(Index)
+                end,
+                onSelected = function(Index)
+   
+                end,
+                onHovered = function()
+   
+                end
+            })
+
+            -- Heritage Slider
+            -- https://rageui.dylan-malandain.io/docs/master/item-slider-heritage
+            RageUI.Item.UISliderHeritage("Heritage Slider", 5, "Description", {
+                onListChange = function(Index)
+
+                end,
+                onSelected = function(Index)
+       
+                end,
+                onHovered = function()
+       
+                end
+            }, 1)
+
+            -- Slider Progress Bar
+            -- https://rageui.dylan-malandain.io/docs/master/item-slider-progress
+            RageUI.Item.SliderProgress("Progress Slider", {1,2,3,4,5,6}, 2, "Description", {}, true, {
+                onListChange = function(Index)
+       
+                end,
+                onSelected = function(Index)
+       
+                end,
+                onHovered = function()
+       
+                end
+           })
+
+        end, function() 
+            -- Panels
+        end)
+
+        -- Panels Menu
+        RageUI.IsVisible(panelsMenu, function()
+            -- Items
+            RageUI.Item.Button('Colour Panel', "", { RightLabel = "" }, true, {})
+
+            RageUI.Item.Button('Grid Panel', "", { RightLabel = "" }, true, {})
+
+            RageUI.Item.Button('Horizontal Grid Panel', "", { RightLabel = "" }, true, {})
+
+            RageUI.Item.Button('Vertical Grid Panel', "", { RightLabel = "" }, true, {})
+
+            RageUI.Item.Button('Percentage Panel', "", { RightLabel = "" }, true, {})
+
+            RageUI.Item.Button('Statistics Panel', "", { RightLabel = "" }, true, {})
+
+            RageUI.Item.Button('Advanced Statistics Panel', "", { RightLabel = "" }, true, {})
+        end, function() 
+            -- Panels
+            RageUI.Panel.ColourPanel('Haircut Colours', RageUI.PanelColour.HairCut, 5, {
                 onColourChange = function(Index)
 
                 end,
@@ -88,7 +219,7 @@ Citizen.CreateThread(function()
                 end
             }, 1)
 
-            RageUI.Panel.Grid(0.5, 0.2, 'TopText', 'BottomText', 'LeftText', 'RightText', {
+            RageUI.Panel.Grid(0.5, 0.2, 'Top', 'Bottom', 'Left', 'Right', {
                 onPositionChange = function(X, Y)
                     print(X, Y)
                 end,
@@ -97,7 +228,7 @@ Citizen.CreateThread(function()
                 end
             }, 2)
 
-            RageUI.Panel.GridHorizontal(0.1, 'LeftText', 'RightText', {
+            RageUI.Panel.GridHorizontal(0.1, 'Left', 'Right', {
                 onPositionChange = function(X, Y)
                     print(X, Y)
                 end,
@@ -106,7 +237,7 @@ Citizen.CreateThread(function()
                 end
             }, 3)
 
-            RageUI.Panel.GridVertical(0.1, 'TopText', 'BottomText', {
+            RageUI.Panel.GridVertical(0.1, 'Top', 'Bottom', {
                 onPositionChange = function(X, Y)
                     print(X, Y)
                 end,
@@ -115,7 +246,7 @@ Citizen.CreateThread(function()
                 end
             }, 4)
 
-            RageUI.Panel.PercentagePanel(1.0, "HeaderText", "MinText", "MaxText", {
+            RageUI.Panel.PercentagePanel(1.0, "Percentage Panel", "0", "1", {
                 onPercentageChange = function(Percentage)
                     print(Percentage)
                 end,
@@ -124,8 +255,13 @@ Citizen.CreateThread(function()
                 end
             }, 5)
 
+            RageUI.Panel.StatisticPanel(0.5, "Statistic #1", 6)
+            RageUI.Panel.StatisticPanel(0.7, "Statistic #2", 6)
+            RageUI.Panel.StatisticPanel(0.2, "Statistic #3", 6)
+
+            RageUI.Panel.StatisticPanelAdvanced("Statistic #1", 0.2, {255,0,0,255}, 0.8, {0,255,0,255}, {255,255,255,255}, 7)
+            RageUI.Panel.StatisticPanelAdvanced("Statistic #2", 0.8, {255,0,0,255}, 0, {0,255,0,255}, {255,255,255,255}, 7)
+            RageUI.Panel.StatisticPanelAdvanced("Statistic #1", 0.6, {255,0,0,255}, 0.1, {0,255,0,255}, {255,255,255,255}, 7)
         end)
-
-
     end
 end)

--- a/example.lua
+++ b/example.lua
@@ -53,7 +53,7 @@ panelsMenu:DisplayGlare(true)
 panelsMenu.EnableMouse = true
 panelsMenu:DisplayInstructionalButton(false)
 
--- It's not required to use a sprite.
+-- It's not required to use a sprite banner.
 heritageMenu:SetRectangleBanner(0,25,0,255)
 panelsMenu:DisplayGlare(true)
 

--- a/menu/RageUI.lua
+++ b/menu/RageUI.lua
@@ -408,7 +408,11 @@ function RageUI.Banner()
         if CurrentMenu() and (CurrentMenu.Display.Header) then
             RageUI.ItemsSafeZone(CurrentMenu)
             if CurrentMenu.Sprite.Dictionary then
-                RenderSprite(CurrentMenu.Sprite.Dictionary, CurrentMenu.Sprite.Texture, CurrentMenu.X, CurrentMenu.Y, RageUI.Settings.Items.Title.Background.Width + CurrentMenu.WidthOffset, RageUI.Settings.Items.Title.Background.Height, CurrentMenu.Sprite.Color.R, CurrentMenu.Sprite.Color.G, CurrentMenu.Sprite.Color.B, CurrentMenu.Sprite.Color.A)
+                if(CurrentMenu.Sprite.Dictionary == "commonmenu") then
+                    RenderSprite(CurrentMenu.Sprite.Dictionary, CurrentMenu.Sprite.Texture, CurrentMenu.X, CurrentMenu.Y, RageUI.Settings.Items.Title.Background.Width + CurrentMenu.WidthOffset, RageUI.Settings.Items.Title.Background.Height, CurrentMenu.Sprite.Color.R, CurrentMenu.Sprite.Color.G, CurrentMenu.Sprite.Color.B, CurrentMenu.Sprite.Color.A)
+                else 
+                    RenderSprite(CurrentMenu.Sprite.Dictionary, CurrentMenu.Sprite.Texture, CurrentMenu.X, CurrentMenu.Y, RageUI.Settings.Items.Title.Background.Width + CurrentMenu.WidthOffset, RageUI.Settings.Items.Title.Background.Height, nil)
+                end
             else
                 RenderRectangle(CurrentMenu.X, CurrentMenu.Y, RageUI.Settings.Items.Title.Background.Width + CurrentMenu.WidthOffset, RageUI.Settings.Items.Title.Background.Height, CurrentMenu.Rectangle.R, CurrentMenu.Rectangle.G, CurrentMenu.Rectangle.B, CurrentMenu.Rectangle.A)
             end

--- a/menu/RageUI.lua
+++ b/menu/RageUI.lua
@@ -407,7 +407,7 @@ function RageUI.Banner()
     if CurrentMenu ~= nil then
         if CurrentMenu() and (CurrentMenu.Display.Header) then
             RageUI.ItemsSafeZone(CurrentMenu)
-            if CurrentMenu.Sprite.Dictionary then
+            if CurrentMenu.Sprite ~= nil then
                 if(CurrentMenu.Sprite.Dictionary == "commonmenu") then
                     RenderSprite(CurrentMenu.Sprite.Dictionary, CurrentMenu.Sprite.Texture, CurrentMenu.X, CurrentMenu.Y, RageUI.Settings.Items.Title.Background.Width + CurrentMenu.WidthOffset, RageUI.Settings.Items.Title.Background.Height, CurrentMenu.Sprite.Color.R, CurrentMenu.Sprite.Color.G, CurrentMenu.Sprite.Color.B, CurrentMenu.Sprite.Color.A)
                 else 

--- a/menu/items/UISliderProgress.lua
+++ b/menu/items/UISliderProgress.lua
@@ -142,13 +142,13 @@ function RageUI.Item.SliderProgress(Label, Items, StartedAtIndex, Description, S
                 if (type(Style.ProgressBackgroundColor) == "table") then
                     RenderRectangle(CurrentMenu.X + SettingsSlider.Background.X + CurrentMenu.WidthOffset - RightOffset, CurrentMenu.Y + SettingsSlider.Background.Y + CurrentMenu.SubtitleHeight + RageUI.ItemOffset, SettingsSlider.Background.Width, SettingsSlider.Background.Height, Style.ProgressBackgroundColor.R, Style.ProgressBackgroundColor.G, Style.ProgressBackgroundColor.B, Style.ProgressBackgroundColor.A)
                 else
-                    error("Style ProgressBackgroundColor is not a table or undefined")
+                    RenderRectangle(CurrentMenu.X + SettingsSlider.Background.X + CurrentMenu.WidthOffset - RightOffset, CurrentMenu.Y + SettingsSlider.Background.Y + CurrentMenu.SubtitleHeight + RageUI.ItemOffset, SettingsSlider.Background.Width, SettingsSlider.Background.Height, 0, 0, 0, 255)
                 end
 
                 if (type(Style.ProgressColor) == "table") then
                     RenderRectangle(CurrentMenu.X + SettingsSlider.Slider.X + CurrentMenu.WidthOffset - RightOffset, CurrentMenu.Y + SettingsSlider.Slider.Y + CurrentMenu.SubtitleHeight + RageUI.ItemOffset, (((SettingsSlider.Slider.Width) / (#Items - 1)) * (Index[Option].Current - 1)), SettingsSlider.Slider.Height, Style.ProgressColor.R, Style.ProgressColor.G, Style.ProgressColor.B, Style.ProgressColor.A)
                 else
-                    error("Style ProgressColor is not a table or undefined")
+                    RenderRectangle(CurrentMenu.X + SettingsSlider.Slider.X + CurrentMenu.WidthOffset - RightOffset, CurrentMenu.Y + SettingsSlider.Slider.Y + CurrentMenu.SubtitleHeight + RageUI.ItemOffset, (((SettingsSlider.Slider.Width) / (#Items - 1)) * (Index[Option].Current - 1)), SettingsSlider.Slider.Height, 255, 255, 255, 255)
                 end
 
                 RageUI.ItemOffset = RageUI.ItemOffset + SettingsButton.Rectangle.Height


### PR DESCRIPTION
Re-wrote example menu to include all the items and panels and includes a heritage example.

Added more submenus and changed some defaults to show how you can customise your window.

Fixed some bugs i caught while making it.

Example now looks like this:

https://i1.lensdump.com/i/jaFvZq.png
https://i1.lensdump.com/i/jaFLsA.png
https://i1.lensdump.com/i/jaFMuM.png
https://i1.lensdump.com/i/jaFoAQ.png